### PR TITLE
Add ability to create files based on config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .vscode
+.vs
 bin/
 obj/
 .vscode/*

--- a/Commands/GenerarateFilesFromConfigCommand.cs
+++ b/Commands/GenerarateFilesFromConfigCommand.cs
@@ -1,0 +1,123 @@
+using SqlFileizer.Data;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Xml;
+
+namespace SqlFileizer.Commands
+{
+    public class GenerateFilesFromConfigCommand: ICommand
+    {
+        public string CommandName => "filesFromConfig";
+
+        public char CommandShortcut => '4';
+
+        public string Description => "Generate sql files from results of SQL query specified in config file";
+
+        public string[] ArgDefinitions => new string[] 
+        { 
+            "Config file name (path not required if config file is in current directory)"
+        };
+
+        public void Execute(string[] args)
+        {
+            string step = "";
+            int rowNumber = 0;
+
+            try
+            {
+                string configFile = args[0];
+                
+                step = "Load config file";
+                string config = File.ReadAllText(configFile);
+
+                step = "Convert config file to XML";
+                var configXml = new XmlDocument();
+                configXml.LoadXml(config);
+
+                step = "Get output directory";
+                string outputDirectory = GetTextByTagName(configXml, "OutputDirectory");
+
+                step = "Get connection string";
+                string connectionString = GetTextByTagName(configXml, "ConnectionString");
+
+                step = "Get SQL query";
+                string sqlQuery = GetTextByTagName(configXml, "SqlQuery");
+
+                step = "Create output directory if not exists";
+                Directory.CreateDirectory(outputDirectory);
+
+                step = "Execute SQl query";
+                //output message to make it clear we're doing something since it takes awhile for the connection to time out if it's a bad connection string
+                Console.WriteLine("Connecting to database with connection string: " + connectionString);
+                Console.WriteLine();
+                var data = SqlFileizerDbContext.GetData(connectionString, sqlQuery).ToList();
+
+                string[] expectedColumns = { "FileName", "FileExtension", "BodyText", "HeaderText", "FooterText" };
+                string[] dataColumns = data[0].Keys.ToArray();
+                if (!dataColumns.OrderBy(x => x).SequenceEqual(dataColumns.OrderBy(y => y))) // verify that array elements match, order doesn't matter
+                {
+                    string message = String.Format(@"Data columns don't match expected columns.{0}Data columns: {1}{0}Expected columns: {2}{0}",
+                        Environment.NewLine, String.Join(",", expectedColumns), String.Join(", ", dataColumns));
+
+                    throw new Exception(message);
+                }
+
+                step = "Write files to output folder";
+                for (int i = 0; i < data.Count; i++)
+                {
+                    rowNumber = i + 1; //rowNumber starts at 1 instead of 0
+                    var row = data[i];
+
+                    string fileNameWithPath = Path.Combine(outputDirectory, row["FileName"] + "." + row["FileExtension"]);
+
+                    var fileText = new StringBuilder();
+                    string header = row["HeaderText"].ToString().Trim();
+                    string content = row["FileContent"].ToString().Trim();
+                    string footer = row["FooterText"].ToString().Trim();
+
+                    if (header.Length > 0)
+                    {
+                        fileText.AppendLine(header);
+                        fileText.AppendLine("go");
+                    }
+
+                    if (content.Length == 0) { throw new Exception("No content found for data row " + rowNumber.ToString());  }
+                    fileText.AppendLine(content);
+
+                    if (footer.Length > 0)
+                    {
+                        fileText.AppendLine("go");
+                        fileText.AppendLine(footer);
+                    }
+
+                    File.WriteAllText(fileNameWithPath, fileText.ToString());
+                }
+
+                Console.WriteLine("Files successfully written to " + outputDirectory);
+            }
+            catch (Exception ex)
+            {
+                string message = "Error on following step: " + step;
+                if (rowNumber > 0) { message += "  row number: " + rowNumber.ToString(); }
+                message += "  Error message: " + ex.Message;
+
+                Console.WriteLine(message);
+            }
+        }
+
+        private string GetTextByTagName (XmlDocument xmlDoc, string tagName)
+        {
+            XmlElement element = (XmlElement)xmlDoc.GetElementsByTagName(tagName)[0];
+
+            if (element == null)
+            {
+                throw (new Exception(tagName + " not found in config file"));
+            }
+
+            return element.InnerText;
+        }
+    }
+}

--- a/Commands/GenerateSampleConfigCommand.cs
+++ b/Commands/GenerateSampleConfigCommand.cs
@@ -1,0 +1,57 @@
+using System;
+using System.IO;
+using SqlFileizer.Data;
+
+namespace SqlFileizer.Commands
+{
+    public class GenerateSampleConfigCommand : ICommand
+    {
+          /// <summary>
+        /// Sample config file; default to scripting out all procs in a given database
+        /// </summary>
+        /// <returns></returns>
+        private static string _sampleConfigText = @"
+<config>
+    <OutputDirectory>procs</OutputDirectory>
+    <ConnectionString>Server=ServerName;Database=DatabaseName;Trusted_Connection=True;</ConnectionString>
+
+    <!-- Result set is parsed based on column names, not order -->
+    <!-- FileName: name of file without extension -->
+    <!-- FileExtension: do not include the dot -->
+    <!-- FileContent: only handles text output for now (no binary support) -->
+    <!-- HeaderText: to be appended to the beginning of each file; separated from body by ""go"" directive -->
+    <!-- FooterText: to be appended to the end of each file; separated from body by ""go"" directive -->
+    <SqlQuery>
+        select o.name as FileName,
+	        'sql' as FileExtension,
+	        definition as BodyText,
+	        'if object_id(''' + o.name + ''') is not null drop procedure ' + o.name as HeaderText,
+	        '' as FooterText
+        from sys.sql_modules m
+	        join sys.objects o on m.object_id = o.object_id
+        where o.type_desc = 'SQL_STORED_PROCEDURE'
+    </SqlQuery>
+</config>
+";
+        public string CommandName => "config";
+
+        public char CommandShortcut => '3';
+
+        public string Description => "Create sample config file to be used for generating one file per row in a SQL result set";
+
+        public string[] ArgDefinitions => new string[0];
+
+        public void Execute(string[] args)
+        {
+            string fileName = "configSample.txt";
+            string currentDirectory = Environment.CurrentDirectory;
+
+            Console.WriteLine("Creating " + fileName + " in " + currentDirectory);
+
+            File.WriteAllText(Path.Combine(currentDirectory, fileName), _sampleConfigText);
+
+            Console.WriteLine();
+            Console.WriteLine(fileName + " created in " + Environment.CurrentDirectory);
+        }
+    }
+}

--- a/Data/SqlFileizerDbContext.cs
+++ b/Data/SqlFileizerDbContext.cs
@@ -49,11 +49,11 @@ namespace SqlFileizer.Data
         public static IEnumerable<Dictionary<string,object>> GetAllStoredProcsFromDB(string connectionString)
         {
             var sql = @"
-                select ROUTINE_SCHEMA [Schema], ROUTINE_NAME [ProcName], ROUTINE_DEFINITION [ProcValue]
+				select ROUTINE_SCHEMA[Schema], ROUTINE_NAME[ProcName], ROUTINE_DEFINITION[ProcValue]
                 from INFORMATION_SCHEMA.ROUTINES
                 where ROUTINE_TYPE = 'PROCEDURE'
-                order by ROUTINE_NAME asc";
-            return GetData(connectionString, sql);
+                order by ROUTINE_NAME asc";            
+			return GetData(connectionString, sql);
         }
 
     }

--- a/Data/SqlFileizerDbContext.cs
+++ b/Data/SqlFileizerDbContext.cs
@@ -8,8 +8,7 @@ namespace SqlFileizer.Data
     {
         public static IEnumerable<Dictionary<string, object>> GetData(string connectionString, string query)
         {
-            using (SqlConnection connection = new SqlConnection(
-                       connectionString))
+            using (SqlConnection connection = new SqlConnection(connectionString))
             {
                 SqlCommand command = new SqlCommand(query, connection);
                 connection.Open();
@@ -50,12 +49,10 @@ namespace SqlFileizer.Data
         public static IEnumerable<Dictionary<string,object>> GetAllStoredProcsFromDB(string connectionString)
         {
             var sql = @"
-                SELECT sch.name as [Schema], OBJECT_NAME(sm.object_id) AS ProcName, sm.definition as ProcValue
-                FROM sys.sql_modules AS sm  
-                    JOIN sys.objects AS o ON sm.object_id = o.object_id
-                    JOIN sys.schemas sch on o.schema_id = sch.schema_id
-                WHERE o.type = 'P'
-                ORDER BY ProcName asc";
+                select ROUTINE_SCHEMA [Schema], ROUTINE_NAME [ProcName], ROUTINE_DEFINITION [ProcValue]
+                from INFORMATION_SCHEMA.ROUTINES
+                where ROUTINE_TYPE = 'PROCEDURE'
+                order by ROUTINE_NAME asc";
             return GetData(connectionString, sql);
         }
 

--- a/Data/SqlFileizerDbContext.cs
+++ b/Data/SqlFileizerDbContext.cs
@@ -48,11 +48,13 @@ namespace SqlFileizer.Data
         /// <param name="connectionString">The connection string for the DB you want to retrieve procs from.</param>
         public static IEnumerable<Dictionary<string,object>> GetAllStoredProcsFromDB(string connectionString)
         {
-            var sql = @"
-				select ROUTINE_SCHEMA[Schema], ROUTINE_NAME[ProcName], ROUTINE_DEFINITION[ProcValue]
-                from INFORMATION_SCHEMA.ROUTINES
-                where ROUTINE_TYPE = 'PROCEDURE'
-                order by ROUTINE_NAME asc";            
+			var sql = @"
+				SELECT sch.name as [Schema], OBJECT_NAME(sm.object_id) AS ProcName, sm.definition as ProcValue
+				FROM sys.sql_modules AS sm  
+					JOIN sys.objects AS o ON sm.object_id = o.object_id
+					JOIN sys.schemas sch on o.schema_id = sch.schema_id
+				WHERE o.type = 'P'
+				ORDER BY ProcName asc";
 			return GetData(connectionString, sql);
         }
 

--- a/Startup.cs
+++ b/Startup.cs
@@ -11,6 +11,8 @@ namespace SqlFileizer
             List<ICommand> commands = new List<ICommand>();
             commands.Add(new HelpCommand());
             commands.Add(new GenerateFileFromProcsCommand());
+            commands.Add(new GenerateSampleConfigCommand());
+            commands.Add(new GenerateFilesFromConfigCommand());
 
             // TODO: Support non-interactive mode (where user just supplies args and we do something)
             // For now, just showing interactive user interface all the time.

--- a/configFunctions.txt
+++ b/configFunctions.txt
@@ -1,0 +1,22 @@
+
+<config>
+    <OutputDirectory>functions</OutputDirectory>
+    <ConnectionString>Server=phpdxweb08\sembitdev;Database=PHPCustom;Trusted_Connection=True;</ConnectionString>
+
+    <!-- Result set is parsed based on column names, not order -->
+    <!-- FileName: name of file without extension -->
+    <!-- FileExtension: do not include the dot -->
+    <!-- FileContent: only handles text output for now (no binary support) -->
+    <!-- HeaderText: to be appended to the beginning of each file -->
+    <!-- FooterText: to be appended to the end of each file -->
+    <SqlQuery>
+		select o.name as FileName,
+			'sql' as FileExtension,
+			definition as FileContent,
+			'if object_id(''' + o.name + ''') is not null drop function ' + o.name as HeaderText,
+			'' as FooterText
+		from sys.sql_modules m
+			join sys.objects o on m.object_id = o.object_id
+		where o.type_desc in ('SQL_SCALAR_FUNCTION', 'SQL_TABLE_VALUED_FUNCTION')
+    </SqlQuery>
+</config>

--- a/configProcs.txt
+++ b/configProcs.txt
@@ -1,0 +1,22 @@
+
+<config>
+    <OutputDirectory>procs</OutputDirectory>
+    <ConnectionString>Server=phpdxweb08\sembitdev;Database=PHPCustom;Trusted_Connection=True;</ConnectionString>
+
+    <!-- Result set is parsed based on column names, not order -->
+    <!-- FileName: name of file without extension -->
+    <!-- FileExtension: do not include the dot -->
+    <!-- FileContent: only handles text output for now (no binary support) -->
+    <!-- HeaderText: to be appended to the beginning of each file -->
+    <!-- FooterText: to be appended to the end of each file -->
+    <SqlQuery>
+        select o.name as FileName,
+	        'sql' as FileExtension,
+	        definition as FileContent,
+	        'if object_id(''' + o.name + ''') is not null drop procedure ' + o.name as HeaderText,
+	        '' as FooterText
+        from sys.sql_modules m
+	        join sys.objects o on m.object_id = o.object_id
+        where o.type_desc = 'SQL_STORED_PROCEDURE'
+    </SqlQuery>
+</config>

--- a/configSample.txt
+++ b/configSample.txt
@@ -1,0 +1,22 @@
+
+<config>
+    <OutputDirectory>procs</OutputDirectory>
+    <ConnectionString>Server=ServerName;Database=DatabaseName;Trusted_Connection=True;</ConnectionString>
+
+    <!-- Result set is parsed based on column names, not order -->
+    <!-- FileName: name of file without extension -->
+    <!-- FileExtension: do not include the dot -->
+    <!-- FileContent: only handles text output for now (no binary support) -->
+    <!-- HeaderText: to be appended to the beginning of each file; separated from body by "go" directive -->
+    <!-- FooterText: to be appended to the end of each file; separated from body by "go" directive -->
+    <SqlQuery>
+        select o.name as FileName,
+	        'sql' as FileExtension,
+	        definition as BodyText,
+	        'if object_id(''' + o.name + ''') is not null drop procedure ' + o.name as HeaderText,
+	        '' as FooterText
+        from sys.sql_modules m
+	        join sys.objects o on m.object_id = o.object_id
+        where o.type_desc = 'SQL_STORED_PROCEDURE'
+    </SqlQuery>
+</config>

--- a/configViews.txt
+++ b/configViews.txt
@@ -1,0 +1,22 @@
+
+<config>
+    <OutputDirectory>views</OutputDirectory>
+    <ConnectionString>Server=phpdxweb08\sembitdev;Database=PHPCustom;Trusted_Connection=True;</ConnectionString>
+
+    <!-- Result set is parsed based on column names, not order -->
+    <!-- FileName: name of file without extension -->
+    <!-- FileExtension: do not include the dot -->
+    <!-- FileContent: only handles text output for now (no binary support) -->
+    <!-- HeaderText: to be appended to the beginning of each file -->
+    <!-- FooterText: to be appended to the end of each file -->
+    <SqlQuery>
+		select o.name as FileName,
+			'sql' as FileExtension,
+			definition as FileContent,
+			'if object_id(''' + o.name + ''') is not null drop view ' + o.name as HeaderText,
+			'' as FooterText
+		from sys.sql_modules m
+			join sys.objects o on m.object_id = o.object_id
+		where o.type_desc = 'VIEW'
+    </SqlQuery>
+</config>

--- a/sql-fileizer.csproj
+++ b/sql-fileizer.csproj
@@ -8,6 +8,7 @@
   <ItemGroup>
     <PackageReference Include="System.Data.Common" Version="4.3.0" />
     <PackageReference Include="System.Data.SqlClient" Version="4.4.2" />
+    <PackageReference Include="System.Xml.XDocument" Version="4.0.11" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Adds two more commands: create sample config file and generate files from config.
Expected usage is to create sample config for first usage the customize config and use it for generating files.
Config file is XML with four elements: OutputDirectory, ConnectionString, and SqlQuery
SqlQuery must have these columns: FileName, FileExtension, BodyText, HeaderText, and FooterText
Used config file since this allows queries to be saved and is easier to work with since queries are awkward on the command line
This is a more generic approach that allows more flexibility in generating multiple files from any SQL query. For example, you can add a where clause to the query to only select object names that contain certain text.